### PR TITLE
corrected many things

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -9,6 +9,7 @@ datasource db {
 
 model User {
   id        Int       @id @default(autoincrement())
+  name      String
   email     String    @unique
   password  String
   role      Role      @default(USER)

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -10,6 +10,7 @@ async function main() {
     where: { email: "admin@nasa.com" },
     update: {},
     create: {
+      name: "NASA Admin",
       email: "admin@nasa.com",
       password: hashedPassword,
       role: "ADMIN",

--- a/apps/api/src/controllers/authController.ts
+++ b/apps/api/src/controllers/authController.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from "@prisma/client";
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import { ENV } from "../env";
+import { AuthRequest } from "../middleware/auth";
 
 const prisma = new PrismaClient();
 
@@ -34,4 +35,110 @@ export const login = async (req: any, res: any) => {
     { expiresIn: "1d" }
   );
   res.json({ token });
+};
+
+export const getProfile = async (req: AuthRequest, res: any) => {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: req.user?.id },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        role: true,
+        createdAt: true
+      }
+    });
+
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    res.json(user);
+  } catch (error) {
+    console.error("Error fetching profile:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+export const updateProfile = async (req: AuthRequest, res: any) => {
+  try {
+    const { name, email } = req.body;
+    const userId = req.user?.id;
+
+    if (!name || !email) {
+      return res.status(400).json({ error: "Name and email are required" });
+    }
+
+    // Check if email is already taken by another user
+    const existingUser = await prisma.user.findFirst({
+      where: {
+        email,
+        id: { not: userId }
+      }
+    });
+
+    if (existingUser) {
+      return res.status(400).json({ error: "Email already exists" });
+    }
+
+    const updatedUser = await prisma.user.update({
+      where: { id: userId },
+      data: { name, email },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        role: true,
+        createdAt: true
+      }
+    });
+
+    res.json(updatedUser);
+  } catch (error) {
+    console.error("Error updating profile:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+export const changePassword = async (req: AuthRequest, res: any) => {
+  try {
+    const { currentPassword, newPassword } = req.body;
+    const userId = req.user?.id;
+
+    if (!currentPassword || !newPassword) {
+      return res.status(400).json({ error: "Current password and new password are required" });
+    }
+
+    if (newPassword.length < 6) {
+      return res.status(400).json({ error: "New password must be at least 6 characters long" });
+    }
+
+    // Get user with password
+    const user = await prisma.user.findUnique({
+      where: { id: userId }
+    });
+
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    // Verify current password
+    const valid = await bcrypt.compare(currentPassword, user.password);
+    if (!valid) {
+      return res.status(400).json({ error: "Current password is incorrect" });
+    }
+
+    // Hash new password and update
+    const hashedNewPassword = await bcrypt.hash(newPassword, 10);
+    await prisma.user.update({
+      where: { id: userId },
+      data: { password: hashedNewPassword }
+    });
+
+    res.json({ message: "Password updated successfully" });
+  } catch (error) {
+    console.error("Error changing password:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
 };

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -15,6 +15,8 @@ export const authenticate = (
   if (!authHeader) return res.status(401).json({ error: "No token provided" });
 
   const token = authHeader.split(" ")[1];
+  if (!token) return res.status(401).json({ error: "No token provided" });
+  
   jwt.verify(token, ENV.JWT_SECRET, (err, decoded) => {
     if (err) return res.status(403).json({ error: "Invalid token" });
     req.user = decoded;

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,9 +1,15 @@
 import { Router } from "express";
-import { signup, login } from "../controllers/authController";
+import { signup, login, getProfile, updateProfile, changePassword } from "../controllers/authController";
+import { authenticate } from "../middleware/auth";
 
 const router = Router();
 
 router.post("/signup", signup);
 router.post("/login", login);
+
+// Protected routes
+router.get("/profile", authenticate, getProfile);
+router.put("/profile", authenticate, updateProfile);
+router.post("/change-password", authenticate, changePassword);
 
 export default router;

--- a/apps/api/src/routes/nasa.ts
+++ b/apps/api/src/routes/nasa.ts
@@ -25,9 +25,16 @@ export const getMissions = async (_req: any, res: any) => {
 };
 
 export const createMission = async (req: any, res: any) => {
-  const { title, description, imageUrl } = req.body;
+  const { title, description, launchDate, status, imageUrl } = req.body;
   const mission = await prisma.mission.create({
-    data: { title, description, imageUrl, userId: req.user.id },
+    data: { 
+      title, 
+      description, 
+      launchDate: new Date(launchDate), 
+      status, 
+      imageUrl, 
+      createdBy: req.user.id 
+    },
   });
   res.json(mission);
 };

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,6 +2,7 @@ import "@repo/ui/styles.css";
 import "./globals.css";
 import type { Metadata } from "next";
 import { Geist } from "next/font/google";
+import { AuthProvider } from "@/contexts/AuthContext";
 
 const geist = Geist({ subsets: ["latin"] });
 
@@ -17,7 +18,11 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={geist.className}>{children}</body>
+      <body className={geist.className}>
+        <AuthProvider>
+          {children}
+        </AuthProvider>
+      </body>
     </html>
   );
 }

--- a/apps/web/components/AdminSettings.tsx
+++ b/apps/web/components/AdminSettings.tsx
@@ -9,6 +9,10 @@ interface AdminProfile {
   createdAt: string;
 }
 
+interface ApiError {
+  error: string;
+}
+
 const AdminSettings: React.FC = () => {
   const [profile, setProfile] = useState<AdminProfile | null>(null);
   const [loading, setLoading] = useState(true);
@@ -35,7 +39,10 @@ const AdminSettings: React.FC = () => {
           }
         });
         
-        if (!response.ok) throw new Error("Failed to fetch profile");
+        if (!response.ok) {
+          const errorData = await response.json() as ApiError;
+          throw new Error(errorData.error || "Failed to fetch profile");
+        }
         
         const data = await response.json();
         setProfile(data);
@@ -85,7 +92,10 @@ const AdminSettings: React.FC = () => {
         })
       });
       
-      if (!response.ok) throw new Error("Failed to update profile");
+      if (!response.ok) {
+        const errorData = await response.json() as ApiError;
+        throw new Error(errorData.error || "Failed to update profile");
+      }
       
       const data = await response.json();
       setProfile(data);
@@ -125,7 +135,10 @@ const AdminSettings: React.FC = () => {
         })
       });
       
-      if (!response.ok) throw new Error("Failed to update password");
+      if (!response.ok) {
+        const errorData = await response.json() as ApiError;
+        throw new Error(errorData.error || "Failed to update password");
+      }
       
       setUpdateSuccess(true);
       setFormData(prev => ({

--- a/apps/web/components/AdminSidebar.tsx
+++ b/apps/web/components/AdminSidebar.tsx
@@ -1,14 +1,49 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
 
 interface SidebarProps {
   activeTab: string;
   setActiveTab: (tab: string) => void;
 }
 
+interface UserProfile {
+  id: number;
+  name: string;
+  email: string;
+  role: string;
+}
+
 const AdminSidebar: React.FC<SidebarProps> = ({ activeTab, setActiveTab }) => {
   const router = useRouter();
+  const [user, setUser] = useState<UserProfile | null>(null);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  useEffect(() => {
+    const fetchUserProfile = async () => {
+      try {
+        const token = localStorage.getItem("token");
+        if (!token) return;
+        
+        const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002";
+        const response = await fetch(`${API_URL}/auth/profile`, {
+          headers: {
+            Authorization: `Bearer ${token}`
+          }
+        });
+        
+        if (response.ok) {
+          const data = await response.json();
+          setUser(data);
+        }
+      } catch (error) {
+        console.error("Error fetching user profile:", error);
+      }
+    };
+    
+    fetchUserProfile();
+  }, []);
 
   const handleSignOut = () => {
     localStorage.removeItem("token");
@@ -61,10 +96,38 @@ const AdminSidebar: React.FC<SidebarProps> = ({ activeTab, setActiveTab }) => {
           </nav>
         </div>
         
-        <div className="mt-auto">
+        <div className="mt-auto space-y-4">
+          {/* User Profile Section */}
+          {user && (
+            <motion.div 
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="bg-gray-800/50 rounded-lg p-4 border border-gray-700"
+            >
+              <div className="flex items-center space-x-3">
+                <div className="bg-blue-600/30 p-2 rounded-full">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-blue-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                  </svg>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-white truncate">
+                    {user.name}
+                  </p>
+                  <p className="text-xs text-gray-400 truncate">
+                    {user.email}
+                  </p>
+                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-600/20 text-blue-300 mt-1">
+                    {user.role}
+                  </span>
+                </div>
+              </div>
+            </motion.div>
+          )}
+          
           <button
             onClick={handleSignOut}
-            className="w-full flex items-center px-4 py-3 text-red-400 hover:bg-red-600/20 hover:text-red-300 rounded-lg"
+            className="w-full flex items-center px-4 py-3 text-red-400 hover:bg-red-600/20 hover:text-red-300 rounded-lg transition-colors duration-200"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />

--- a/apps/web/components/Navbar.tsx
+++ b/apps/web/components/Navbar.tsx
@@ -4,14 +4,19 @@ import React, { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+import { motion, AnimatePresence } from "framer-motion";
 
 export default function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [showAdminPopup, setShowAdminPopup] = useState(false);
+  const [showUserMenu, setShowUserMenu] = useState(false);
   const router = useRouter();
+  const { state, logout } = useAuth();
 
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
   const toggleAdminPopup = () => setShowAdminPopup(!showAdminPopup);
+  const toggleUserMenu = () => setShowUserMenu(!showUserMenu);
   
   const handleAdminSignIn = () => {
     router.push("/auth/signin");
@@ -58,26 +63,120 @@ export default function Navbar() {
           </button>
         </div>
 
-        {/* Desktop Sign In Button */}
-        <div className="hidden md:flex items-center">
-          <a 
-            href="/auth/signin"
-            className="group flex items-center justify-center gap-2 bg-white text-black font-semibold px-5 py-2 rounded-full text-sm shadow-md hover:bg-gray-200 hover:shadow-lg transform transition-all duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-50"
-          >
-            <span>Sign in as Admin</span>
-            <svg
-              className="w-4 h-4 transition-transform duration-300 group-hover:translate-x-1"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
+        {/* Desktop Auth Section */}
+        <div className="hidden md:flex items-center relative">
+          {state.user ? (
+            /* User is logged in - show profile */
+            <div className="relative">
+              <button
+                onClick={toggleUserMenu}
+                className="group flex items-center gap-3 bg-white/10 hover:bg-white/20 text-white px-4 py-2 rounded-full text-sm shadow-md transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-blue-400"
+              >
+                <div className="bg-blue-600/30 p-1.5 rounded-full">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-blue-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                  </svg>
+                </div>
+                <span className="font-medium">{state.user.name}</span>
+                <svg className={`w-4 h-4 transition-transform duration-200 ${showUserMenu ? 'rotate-180' : ''}`} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
+                </svg>
+              </button>
+              
+              {/* User dropdown menu */}
+              <AnimatePresence>
+                {showUserMenu && (
+                  <motion.div
+                    initial={{ opacity: 0, y: -10, scale: 0.95 }}
+                    animate={{ opacity: 1, y: 0, scale: 1 }}
+                    exit={{ opacity: 0, y: -10, scale: 0.95 }}
+                    transition={{ duration: 0.2 }}
+                    className="absolute right-0 top-full mt-2 w-64 bg-black/90 backdrop-blur-xl border border-gray-700 rounded-xl shadow-2xl z-50"
+                  >
+                    <div className="p-4">
+                      <div className="flex items-center gap-3 mb-4 pb-3 border-b border-gray-700">
+                        <div className="bg-blue-600/30 p-2 rounded-full">
+                          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-blue-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                          </svg>
+                        </div>
+                        <div>
+                          <p className="text-white font-medium">{state.user.name}</p>
+                          <p className="text-gray-400 text-sm">{state.user.email}</p>
+                          <span className="inline-block bg-blue-600/20 text-blue-300 text-xs px-2 py-0.5 rounded-full mt-1">
+                            {state.user.role}
+                          </span>
+                        </div>
+                      </div>
+                      
+                      <div className="space-y-2">
+                        <Link
+                          href="/admin"
+                          onClick={() => setShowUserMenu(false)}
+                          className="block text-gray-300 hover:text-white hover:bg-white/10 px-3 py-2 rounded-lg transition-colors duration-200 flex items-center gap-2"
+                        >
+                          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+                          </svg>
+                          Admin Dashboard
+                        </Link>
+                        
+                        <button
+                          onClick={() => {
+                            router.push('/admin?tab=settings');
+                            setShowUserMenu(false);
+                          }}
+                          className="w-full text-left text-gray-300 hover:text-white hover:bg-white/10 px-3 py-2 rounded-lg transition-colors duration-200 flex items-center gap-2"
+                        >
+                          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                          </svg>
+                          Profile Settings
+                        </button>
+                        
+                        <hr className="border-gray-700 my-2" />
+                        
+                        <button
+                          onClick={() => {
+                            logout();
+                            setShowUserMenu(false);
+                            router.push('/');
+                          }}
+                          className="w-full text-left text-red-400 hover:text-red-300 hover:bg-red-900/20 px-3 py-2 rounded-lg transition-colors duration-200 flex items-center gap-2"
+                        >
+                          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                          </svg>
+                          Sign Out
+                        </button>
+                      </div>
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+          ) : (
+            /* User is not logged in - show sign in button */
+            <a 
+              href="/auth/signin"
+              className="group flex items-center justify-center gap-2 bg-white text-black font-semibold px-5 py-2 rounded-full text-sm shadow-md hover:bg-gray-200 hover:shadow-lg transform transition-all duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-50"
             >
-              <path
-                fillRule="evenodd"
-                d="M3 10a.75.75 0 01.75-.75h10.638L10.23 5.29a.75.75 0 111.04-1.08l5.5 5.25a.75.75 0 010 1.08l-5.5 5.25a.75.75 0 11-1.04-1.08l4.158-3.96H3.75A.75.75 0 013 10z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </a>
+              <span>Sign in as Admin</span>
+              <svg
+                className="w-4 h-4 transition-transform duration-300 group-hover:translate-x-1"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M3 10a.75.75 0 01.75-.75h10.638L10.23 5.29a.75.75 0 111.04-1.08l5.5 5.25a.75.75 0 010 1.08l-5.5 5.25a.75.75 0 11-1.04-1.08l4.158-3.96H3.75A.75.75 0 013 10z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </a>
+          )}
         </div>
 
         {/* Mobile Menu Button */}

--- a/apps/web/contexts/AuthContext.tsx
+++ b/apps/web/contexts/AuthContext.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import React, { createContext, useContext, useReducer, useEffect, useCallback, ReactNode } from 'react';
+import { validateToken, JwtPayload } from '@/lib/jwt';
+
+// Types
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  role: string;
+  createdAt: string;
+}
+
+export interface AuthState {
+  user: User | null;
+  token: string | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export type AuthAction =
+  | { type: 'INIT_START' }
+  | { type: 'INIT_SUCCESS'; payload: { user: User; token: string } }
+  | { type: 'INIT_ERROR'; payload: string }
+  | { type: 'LOGIN_START' }
+  | { type: 'LOGIN_SUCCESS'; payload: { user: User; token: string } }
+  | { type: 'LOGIN_ERROR'; payload: string }
+  | { type: 'LOGOUT' }
+  | { type: 'CLEAR_ERROR' };
+
+// Initial state
+const initialState: AuthState = {
+  user: null,
+  token: null,
+  loading: true,
+  error: null,
+};
+
+// Reducer
+function authReducer(state: AuthState, action: AuthAction): AuthState {
+  switch (action.type) {
+    case 'INIT_START':
+      return { ...state, loading: true, error: null };
+    
+    case 'INIT_SUCCESS':
+      return {
+        ...state,
+        user: action.payload.user,
+        token: action.payload.token,
+        loading: false,
+        error: null,
+      };
+    
+    case 'INIT_ERROR':
+      return {
+        ...state,
+        user: null,
+        token: null,
+        loading: false,
+        error: action.payload,
+      };
+    
+    case 'LOGIN_START':
+      return { ...state, loading: true, error: null };
+    
+    case 'LOGIN_SUCCESS':
+      return {
+        ...state,
+        user: action.payload.user,
+        token: action.payload.token,
+        loading: false,
+        error: null,
+      };
+    
+    case 'LOGIN_ERROR':
+      return {
+        ...state,
+        user: null,
+        token: null,
+        loading: false,
+        error: action.payload,
+      };
+    
+    case 'LOGOUT':
+      return {
+        ...state,
+        user: null,
+        token: null,
+        loading: false,
+        error: null,
+      };
+    
+    case 'CLEAR_ERROR':
+      return { ...state, error: null };
+    
+    default:
+      return state;
+  }
+}
+
+// Context
+const AuthContext = createContext<{
+  state: AuthState;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+  clearError: () => void;
+  refreshUser: () => Promise<void>;
+} | null>(null);
+
+// Provider component
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(authReducer, initialState);
+
+  // Initialize authentication state
+  useEffect(() => {
+    const initAuth = async () => {
+      try {
+        dispatch({ type: 'INIT_START' });
+        
+        // Check if we're in the browser
+        if (typeof window === 'undefined') {
+          dispatch({ type: 'INIT_ERROR', payload: 'Server-side rendering' });
+          return;
+        }
+        
+        const token = localStorage.getItem('token');
+        if (!token) {
+          dispatch({ type: 'INIT_ERROR', payload: 'No token found' });
+          return;
+        }
+
+        const validation = validateToken(token);
+        if (!validation.valid || !validation.payload) {
+          localStorage.removeItem('token');
+          dispatch({ type: 'INIT_ERROR', payload: validation.error || 'Invalid token' });
+          return;
+        }
+
+        // Fetch fresh user data from API
+        const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3002';
+        const response = await fetch(`${API_URL}/auth/profile`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        if (!response.ok) {
+          localStorage.removeItem('token');
+          dispatch({ type: 'INIT_ERROR', payload: 'Failed to fetch user profile' });
+          return;
+        }
+
+        const user = await response.json();
+        dispatch({ type: 'INIT_SUCCESS', payload: { user, token } });
+      } catch (error) {
+        localStorage.removeItem('token');
+        dispatch({ 
+          type: 'INIT_ERROR', 
+          payload: error instanceof Error ? error.message : 'Initialization failed' 
+        });
+      }
+    };
+
+    initAuth();
+  }, []);
+
+  // Login function
+  const login = async (email: string, password: string): Promise<void> => {
+    try {
+      console.log('🔐 Starting login process...');
+      dispatch({ type: 'LOGIN_START' });
+      
+      const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3002';
+      console.log('🌐 API URL:', API_URL);
+      
+      const response = await fetch(`${API_URL}/auth/login`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email, password }),
+      });
+
+      const data = await response.json();
+      console.log('📡 Login response:', response.status, response.ok);
+
+      if (!response.ok) {
+        console.error('❌ Login failed:', data);
+        throw new Error(data.error || 'Login failed');
+      }
+
+      console.log('✅ Login successful, validating token...');
+      // Validate token
+      const validation = validateToken(data.token);
+      if (!validation.valid || !validation.payload) {
+        console.error('❌ Token validation failed:', validation);
+        throw new Error('Received invalid token from server');
+      }
+
+      console.log('🔑 Token valid, storing and fetching profile...');
+      // Store token
+      localStorage.setItem('token', data.token);
+
+      // Fetch user profile
+      const profileResponse = await fetch(`${API_URL}/auth/profile`, {
+        headers: {
+          Authorization: `Bearer ${data.token}`,
+        },
+      });
+
+      if (!profileResponse.ok) {
+        console.error('❌ Profile fetch failed:', profileResponse.status);
+        throw new Error('Failed to fetch user profile after login');
+      }
+
+      const user = await profileResponse.json();
+      console.log('👤 User profile fetched:', user);
+      console.log('🎉 Dispatching LOGIN_SUCCESS...');
+      dispatch({ type: 'LOGIN_SUCCESS', payload: { user, token: data.token } });
+      console.log('✅ Login process complete!');
+    } catch (error) {
+      console.error('💥 Login error:', error);
+      dispatch({ 
+        type: 'LOGIN_ERROR', 
+        payload: error instanceof Error ? error.message : 'Login failed' 
+      });
+      throw error;
+    }
+  };
+
+  // Logout function
+  const logout = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('token');
+      localStorage.removeItem('adminCategory');
+    }
+    dispatch({ type: 'LOGOUT' });
+  };
+
+  // Clear error function (memoized to prevent infinite loops)
+  const clearError = useCallback(() => {
+    dispatch({ type: 'CLEAR_ERROR' });
+  }, []);
+
+  // Refresh user data
+  const refreshUser = async (): Promise<void> => {
+    try {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      
+      const token = localStorage.getItem('token');
+      if (!token) {
+        logout();
+        return;
+      }
+
+      const validation = validateToken(token);
+      if (!validation.valid) {
+        logout();
+        return;
+      }
+
+      const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3002';
+      const response = await fetch(`${API_URL}/auth/profile`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        logout();
+        return;
+      }
+
+      const user = await response.json();
+      dispatch({ type: 'LOGIN_SUCCESS', payload: { user, token } });
+    } catch (error) {
+      logout();
+    }
+  };
+
+  const value = {
+    state,
+    login,
+    logout,
+    clearError,
+    refreshUser,
+  };
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+// Custom hook to use auth context
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/apps/web/debug-auth.html
+++ b/apps/web/debug-auth.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Auth Debug Test</title>
+</head>
+<body>
+    <h1>Authentication Debug Test</h1>
+    <div>
+        <h2>Test Login</h2>
+        <button onclick="testLogin()">Test Login API</button>
+        <div id="result"></div>
+    </div>
+
+    <script>
+        async function testLogin() {
+            const resultDiv = document.getElementById('result');
+            resultDiv.innerHTML = 'Testing...';
+            
+            try {
+                console.log('🔐 Testing login API...');
+                
+                const response = await fetch('http://localhost:3002/auth/login', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ 
+                        email: 'admin@nasa.com', 
+                        password: 'admin123' 
+                    }),
+                });
+
+                console.log('📡 Response status:', response.status);
+                const data = await response.json();
+                console.log('📡 Response data:', data);
+
+                if (response.ok) {
+                    resultDiv.innerHTML = `
+                        <h3>✅ Login Success!</h3>
+                        <p>Token: ${data.token ? 'Received' : 'Missing'}</p>
+                        <p>Token length: ${data.token ? data.token.length : 'N/A'}</p>
+                        
+                        <h4>Testing profile API...</h4>
+                    `;
+                    
+                    // Test profile endpoint
+                    const profileResponse = await fetch('http://localhost:3002/auth/profile', {
+                        headers: {
+                            'Authorization': `Bearer ${data.token}`
+                        }
+                    });
+                    
+                    console.log('👤 Profile response status:', profileResponse.status);
+                    const profileData = await profileResponse.json();
+                    console.log('👤 Profile data:', profileData);
+                    
+                    if (profileResponse.ok) {
+                        resultDiv.innerHTML += `
+                            <h4>✅ Profile Success!</h4>
+                            <p>User ID: ${profileData.id}</p>
+                            <p>Email: ${profileData.email}</p>
+                            <p>Role: ${profileData.role}</p>
+                            <p>Name: ${profileData.name || 'N/A'}</p>
+                        `;
+                    } else {
+                        resultDiv.innerHTML += `
+                            <h4>❌ Profile Failed!</h4>
+                            <p>Status: ${profileResponse.status}</p>
+                            <p>Error: ${JSON.stringify(profileData)}</p>
+                        `;
+                    }
+                } else {
+                    resultDiv.innerHTML = `
+                        <h3>❌ Login Failed!</h3>
+                        <p>Status: ${response.status}</p>
+                        <p>Error: ${JSON.stringify(data)}</p>
+                    `;
+                }
+            } catch (error) {
+                console.error('💥 Error:', error);
+                resultDiv.innerHTML = `
+                    <h3>💥 Error!</h3>
+                    <p>${error.message}</p>
+                `;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/apps/web/lib/jwt.ts
+++ b/apps/web/lib/jwt.ts
@@ -1,0 +1,58 @@
+import { jwtDecode } from 'jwt-decode';
+
+export interface JwtPayload {
+  id: number;
+  email: string;
+  role: string;
+  exp: number;
+  iat: number;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  payload?: JwtPayload;
+  error?: string;
+}
+
+export function validateToken(token: string): ValidationResult {
+  try {
+    if (!token) {
+      return { valid: false, error: 'No token provided' };
+    }
+
+    const decoded = jwtDecode<JwtPayload>(token);
+    
+    // Check if token is expired
+    const now = Math.floor(Date.now() / 1000);
+    if (decoded.exp && decoded.exp < now) {
+      return { valid: false, error: 'Token expired' };
+    }
+
+    return { valid: true, payload: decoded };
+  } catch (error) {
+    return { 
+      valid: false, 
+      error: error instanceof Error ? error.message : 'Invalid token' 
+    };
+  }
+}
+
+export function isTokenExpiring(token: string, bufferMinutes: number = 5): boolean {
+  try {
+    const decoded = jwtDecode<JwtPayload>(token);
+    const now = Math.floor(Date.now() / 1000);
+    const expirationBuffer = bufferMinutes * 60;
+    
+    return decoded.exp ? (decoded.exp - now) < expirationBuffer : false;
+  } catch {
+    return true; // Treat invalid tokens as expiring
+  }
+}
+
+export function getTokenPayload(token: string): JwtPayload | null {
+  try {
+    return jwtDecode<JwtPayload>(token);
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/lib/withAuth.tsx
+++ b/apps/web/lib/withAuth.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+export interface WithAuthOptions {
+  requireAdmin?: boolean;
+  redirectTo?: string;
+}
+
+export function withAuth<P extends object>(
+  Component: React.ComponentType<P>,
+  options: WithAuthOptions = {}
+) {
+  const {
+    requireAdmin = true,
+    redirectTo = '/auth/signin'
+  } = options;
+
+  return function AuthenticatedComponent(props: P) {
+    const { state } = useAuth();
+    const router = useRouter();
+
+    useEffect(() => {
+      if (!state.loading) {
+        // If no user or token, redirect to login
+        if (!state.user || !state.token) {
+          router.push(redirectTo);
+          return;
+        }
+
+        // If admin required but user is not admin, redirect to login
+        if (requireAdmin && state.user.role !== 'ADMIN') {
+          router.push(redirectTo);
+          return;
+        }
+      }
+    }, [state.loading, state.user, state.token, router]);
+
+    // Show loading while checking authentication
+    if (state.loading) {
+      return (
+        <div className="min-h-screen bg-black flex items-center justify-center">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-16 w-16 border-b-4 border-white mx-auto mb-6"></div>
+            <div className="text-white text-xl">Authenticating...</div>
+          </div>
+        </div>
+      );
+    }
+
+    // Don't render component if user is not authenticated
+    if (!state.user || !state.token) {
+      return null;
+    }
+
+    // Don't render component if admin required but user is not admin
+    if (requireAdmin && state.user.role !== 'ADMIN') {
+      return null;
+    }
+
+    // Render the protected component
+    return <Component {...props} />;
+  };
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "next dev --port 3001 --turbopack",
+    "dev": "next dev --port 3003 --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint --max-warnings 0",
@@ -16,6 +16,7 @@
     "@tsparticles/react": "^3.0.0",
     "@tsparticles/slim": "^3.9.1",
     "clsx": "^2.1.1",
+    "jwt-decode": "^4.0.0",
     "next": "^15.4.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -565,6 +565,7 @@
         "@tsparticles/react": "^3.0.0",
         "@tsparticles/slim": "^3.9.1",
         "clsx": "^2.1.1",
+        "jwt-decode": "^4.0.0",
         "next": "^15.4.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -6446,6 +6447,15 @@
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add end-to-end JWT auth with profile management and a shared AuthContext integrated into the admin UI and navbar. Missions and Projects now load from our API (port 3002) with a NASA fallback, and User now includes a required name.

- **New Features**
  - API: added GET/PUT /auth/profile and POST /auth/change-password; stricter bearer token check.
  - Prisma: added required User.name; seeded admin with name.
  - Frontend auth: new AuthProvider, JWT utils, withAuth; app wrapped in provider; added debug-auth.html.
  - UI: navbar user menu (profile/admin links, sign out); admin pages use context with protected redirects.
  - Data: Missions/Projects fetch from backend first, fall back to NASA; missions show “ADMIN” source when applicable.

- **Refactors**
  - Default API base is http://localhost:3002; web dev runs on port 3003.
  - createMission now accepts launchDate and status and sets createdBy.
  - Admin page reads tab from URL; improved loading states and error messaging in settings.
  - Added jwt-decode dependency.

<!-- End of auto-generated description by cubic. -->

